### PR TITLE
new: Disable breaking rules.

### DIFF
--- a/packages/config-eslint/src/presets/typescript.ts
+++ b/packages/config-eslint/src/presets/typescript.ts
@@ -33,6 +33,12 @@ const config: ESLintConfig = {
         ...typescriptRules,
       },
     },
+    {
+      files: [`*.test.${TSX_EXTS_GROUP}`],
+      rules: {
+        '@typescript-eslint/ban-ts-comment': 'off',
+      },
+    },
   ],
 };
 

--- a/packages/config-eslint/src/rules/promise.ts
+++ b/packages/config-eslint/src/rules/promise.ts
@@ -2,7 +2,7 @@ import { ESLintConfig } from '@beemo/driver-eslint';
 
 const config: ESLintConfig['rules'] = {
   // eslint-plugin-promise rules
-  'promise/always-return': 'error', // return inside each then() to create readable and reusable Promise chains.
+  'promise/always-return': 'off', // return inside each then() to create readable and reusable Promise chains.
   'promise/avoid-new': 'off', // avoid creating new promises outside of utility libs (use pify instead)
   'promise/catch-or-return': 'off', // enforces the use of catch() on un-returned promises
   'promise/no-callback-in-promise': 'error', // avoid calling cb() inside of a then() (use nodeify instead)

--- a/packages/config-eslint/src/rules/react.ts
+++ b/packages/config-eslint/src/rules/react.ts
@@ -16,6 +16,7 @@ const config: ESLintConfig['rules'] = {
   'react/jsx-no-bind': ['warn', { ignoreDOMComponents: true }], // prevents usage of Function.prototype.bind and arrow functions in React component props
   'react/jsx-no-constructed-context-values': 'warn', // prevents JSX context provider values from taking values that will cause needless rerenders
   'react/jsx-no-comment-textnodes': 'warn', // comments inside children section of tag should be placed inside braces
+  'react/jsx-no-literals': 'off', // Prevent usage of string literals in JSX
   'react/jsx-no-script-url': 'error', // forbid javascript: URLs
   'react/jsx-no-useless-fragment': 'error', // disallow unnecessary fragments
   'react/jsx-pascal-case': 'error', // enforce PascalCase for user-defined JSX components

--- a/packages/config-eslint/src/rules/typescript.ts
+++ b/packages/config-eslint/src/rules/typescript.ts
@@ -29,6 +29,7 @@ const config: ESLintConfig['rules'] = {
   'no-useless-constructor': 'off', // disallow unnecessary constructors
   'require-await': 'off', // disallow async functions which have no await expression
   'space-infix-ops': 'off', // require spacing around infix operators
+  quotes: 'off',
 
   // override eslint-plugin-node rules
   'node/file-extension-in-import': [
@@ -338,7 +339,7 @@ const config: ESLintConfig['rules'] = {
   '@typescript-eslint/prefer-string-starts-ends-with': 'off', // enforce the use of String#startsWith and String#endsWith instead of other equivalent methods of checking substrings
   '@typescript-eslint/prefer-ts-expect-error': 'warn', // recommends using // @ts-expect-error over // @ts-ignore
   '@typescript-eslint/promise-function-async': 'warn', // requires any function or method that returns a Promise to be marked async
-  '@typescript-eslint/quotes': 'off', // enforce the consistent use of either backticks, double, or single quotes
+  '@typescript-eslint/quotes': ['error', 'single', { avoidEscape: true }], // enforce the consistent use of either backticks, double, or single quotes
   '@typescript-eslint/require-array-sort-compare': 'warn', // enforce giving compare argument to Array#sort
   '@typescript-eslint/require-await': 'error', // disallow async functions which have no await expression
   '@typescript-eslint/restrict-plus-operands': ['error', { checkCompoundAssignments: true }], // when adding two variables, operands must both be of type number or of type string

--- a/packages/config-eslint/src/rules/typescript.ts
+++ b/packages/config-eslint/src/rules/typescript.ts
@@ -339,7 +339,11 @@ const config: ESLintConfig['rules'] = {
   '@typescript-eslint/prefer-string-starts-ends-with': 'off', // enforce the use of String#startsWith and String#endsWith instead of other equivalent methods of checking substrings
   '@typescript-eslint/prefer-ts-expect-error': 'warn', // recommends using // @ts-expect-error over // @ts-ignore
   '@typescript-eslint/promise-function-async': 'warn', // requires any function or method that returns a Promise to be marked async
-  '@typescript-eslint/quotes': ['error', 'single', { avoidEscape: true }], // enforce the consistent use of either backticks, double, or single quotes
+  '@typescript-eslint/quotes': [
+    'error',
+    'single',
+    { avoidEscape: true, allowTemplateLiterals: false },
+  ], // enforce the consistent use of either backticks, double, or single quotes
   '@typescript-eslint/require-array-sort-compare': 'warn', // enforce giving compare argument to Array#sort
   '@typescript-eslint/require-await': 'error', // disallow async functions which have no await expression
   '@typescript-eslint/restrict-plus-operands': ['error', { checkCompoundAssignments: true }], // when adding two variables, operands must both be of type number or of type string

--- a/packages/config-eslint/src/rules/unicorn.ts
+++ b/packages/config-eslint/src/rules/unicorn.ts
@@ -67,6 +67,10 @@ const config: ESLintConfig['rules'] = {
   'unicorn/prefer-keyboard-event-key': 'warn', // prefer KeyboardEvent#key over KeyboardEvent#keyCode.
   'unicorn/prefer-math-trunc': 'warn', // enforce the use of Math.trunc instead of bitwise operators
   'unicorn/prefer-modern-dom-apis': 'warn', // prefer .before() over .insertBefore(), .replaceWith() over .replaceChild(), prefer one of .before(), .after(), .append() or .prepend() over insertAdjacentText() and insertAdjacentElement()
+  // FIXME [@rajzik]: This is good rule but adoption isn't great so far
+  'unicorn/prefer-module': 'off', // Prefer JavaScript modules (ESM) over CommonJS
+  // FIXME [eslint-plugin-import]: Once https://github.com/benmosher/eslint-plugin-import/issues/2035 is closed can be enabled
+  'unicorn/prefer-node-protocol': 'off', // Prefer using the `node:` protocol when importing Node.js builtin modules
   'unicorn/prefer-negative-index': 'warn', // prefer negative index over .length - index for {String,Array,TypedArray}#slice() and Array#splice()
   'unicorn/prefer-number-properties': 'warn', // prefer Number static properties over global ones
   'unicorn/prefer-optional-catch-binding': 'off', // prefer omitting the catch binding parameter


### PR DESCRIPTION
Note: Disabled rules: `promise/always-return`, `react/jsx-no-literals`, `unicorn/prefer-module`, `unicorn/prefer-node-protocol`, `@typescript-eslint/ban-ts-comment` (only for tests); Enabled rules: `@typescript-eslint/quotes`.