### PR TITLE
feature: Add `checkedFolders` option to settings.

### DIFF
--- a/packages/config-typescript/src/index.ts
+++ b/packages/config-typescript/src/index.ts
@@ -20,6 +20,7 @@ export interface TypeScriptOptions {
   declarationFolder?: string;
   declarationOnly?: boolean;
   skipLibCheck?: boolean;
+  checkedFolders?: string[];
 }
 
 export function getCompilerOptions({
@@ -83,7 +84,7 @@ export function getCompilerOptions({
 }
 
 export function getConfig(options: TypeScriptOptions): TypeScriptConfig {
-  const { workspaces, srcFolder, typesFolder, includeTests, testsFolder } = options;
+  const { workspaces, srcFolder, typesFolder, includeTests, testsFolder, checkedFolders } = options;
   if (workspaces) {
     return {
       compilerOptions: getCompilerOptions(options),
@@ -98,6 +99,12 @@ export function getConfig(options: TypeScriptOptions): TypeScriptConfig {
 
   if (includeTests) {
     tsconfig.include.push(`./${testsFolder}/**/*`);
+  }
+
+  const check = checkedFolders?.map((folder) => `./${folder}/**/*`);
+
+  if (check) {
+    tsconfig.include.push(...check);
   }
 
   return tsconfig;

--- a/packages/lumos/src/configs/eslint.ts
+++ b/packages/lumos/src/configs/eslint.ts
@@ -1,6 +1,6 @@
 import { Path } from '@beemo/core';
 import { getConfig } from '@oriflame/config-eslint';
-import fs from 'fs';
+import fs from 'node:fs';
 import prettier from 'prettier';
 
 import { getSettings } from '../helpers/getSettings';
@@ -10,7 +10,7 @@ const { tool } = process.lumos || process.beemo;
 
 const settings = getSettings(tool, 'eslint');
 
-const { future, node, nextjs, srcFolder, testsFolder, typesFolder } = settings;
+const { future, checkedFolders, node, nextjs, srcFolder, testsFolder, typesFolder } = settings;
 
 const workspacesEnabled = tool.project.getWorkspaceGlobs({ relative: true }).length > 0;
 
@@ -26,6 +26,7 @@ if (workspacesEnabled) {
       new Path(wsPath, `${srcFolder}/**/*`),
       new Path(wsPath, `${testsFolder}/**/*`),
       new Path(wsPath, `${typesFolder}/**/*`),
+      ...(checkedFolders?.map((folder) => new Path(wsPath, `${folder}/**/*`)) ?? []),
     );
   });
 
@@ -49,6 +50,7 @@ if (workspacesEnabled) {
     new Path(`${srcFolder}/**/*`).path(),
     new Path(`${testsFolder}/**/*`).path(),
     new Path(`${typesFolder}/**/*`).path(),
+    ...(checkedFolders?.map((folder) => new Path(`${folder}/**/*`).path()) ?? []),
   ];
 
   const config = JSON.stringify({

--- a/packages/lumos/src/configs/eslint.ts
+++ b/packages/lumos/src/configs/eslint.ts
@@ -22,12 +22,17 @@ if (workspacesEnabled) {
   const include: Path[] = [new Path(`${typesFolder}/**/*`)];
 
   tool.project.getWorkspaceGlobs({ relative: true }).forEach((wsPath) => {
+    const check = checkedFolders?.map((folder) => new Path(wsPath, `${folder}/**/*`));
+
     include.push(
       new Path(wsPath, `${srcFolder}/**/*`),
       new Path(wsPath, `${testsFolder}/**/*`),
       new Path(wsPath, `${typesFolder}/**/*`),
-      ...(checkedFolders?.map((folder) => new Path(wsPath, `${folder}/**/*`)) ?? []),
     );
+
+    if (check) {
+      include.push(...check);
+    }
   });
 
   const config = JSON.stringify({
@@ -46,12 +51,17 @@ if (workspacesEnabled) {
 } else {
   const project = Path.resolve('tsconfig.eslint.json');
 
+  const check = checkedFolders?.map((folder) => new Path(`${folder}/**/*`).path());
+
   const include = [
     new Path(`${srcFolder}/**/*`).path(),
     new Path(`${testsFolder}/**/*`).path(),
     new Path(`${typesFolder}/**/*`).path(),
-    ...(checkedFolders?.map((folder) => new Path(`${folder}/**/*`).path()) ?? []),
   ];
+
+  if (check) {
+    include.push(...check);
+  }
 
   const config = JSON.stringify({
     extends: './tsconfig.json',

--- a/packages/lumos/src/configs/eslint.ts
+++ b/packages/lumos/src/configs/eslint.ts
@@ -1,6 +1,6 @@
 import { Path } from '@beemo/core';
 import { getConfig } from '@oriflame/config-eslint';
-import fs from 'node:fs';
+import fs from 'fs';
 import prettier from 'prettier';
 
 import { getSettings } from '../helpers/getSettings';

--- a/packages/lumos/src/configs/typescript.ts
+++ b/packages/lumos/src/configs/typescript.ts
@@ -19,9 +19,11 @@ const {
   testsFolder,
   buildFolder,
   enableSourceMaps,
+  checkedFolders,
 } = settings;
 
 const usingWorkspaces = tool.project.getWorkspaceGlobs({ relative: true }).length > 0;
+const noEmit = !!context.getRiskyOption('noEmit');
 
 export default getConfig({
   sourceMaps: enableSourceMaps,
@@ -31,11 +33,12 @@ export default getConfig({
   srcFolder,
   allowJs,
   skipLibCheck,
-  includeTests: !!context.getRiskyOption('noEmit'),
+  includeTests: noEmit,
   typesFolder,
   declarationFolder,
   declarationOnly,
   buildFolder,
   testsFolder,
   workspaces: usingWorkspaces,
+  checkedFolders: noEmit ? checkedFolders : undefined,
 });

--- a/packages/lumos/src/index.ts
+++ b/packages/lumos/src/index.ts
@@ -16,7 +16,7 @@ export type LumosConfig = BeemoConfig<Partial<LumosSettings>>;
 export type { ConfigTemplateResult, ConfigTemplateOptions, ConfigObject } from '@beemo/core';
 
 export default function lumos(tool: Tool) {
-  const { srcFolder, testsFolder, esmBuildFolder, buildFolder } = getSettings(tool);
+  const { srcFolder, testsFolder, esmBuildFolder, buildFolder, checkedFolders } = getSettings(tool);
   const usingTypescript = tool.driverRegistry.isRegistered('typescript');
   const workspaces = tool.project.getWorkspaceGlobs({ relative: true });
   const exts = ['.ts', '.tsx', '.js', '.jsx'];
@@ -56,12 +56,18 @@ export default function lumos(tool: Tool) {
     }
 
     if (hasNoParams(context, 'eslint')) {
+      const check = checkedFolders?.join(',');
+      const checkFolders = check ? `,${check}` : '';
       if (workspaces.length > 0) {
         workspaces.forEach((wsPrefix) => {
-          context.addOption(`${wsPrefix}/{${DIR_PATTERN_LIST},${srcFolder},${testsFolder}}`);
+          context.addOption(
+            `${wsPrefix}/{${DIR_PATTERN_LIST},${srcFolder},${testsFolder}${checkFolders}}`,
+          );
         });
       } else {
-        context.addOption(`./{${srcFolder},${testsFolder},${ESLINT_DIRS.join(',')}}`);
+        context.addOption(
+          `./{${srcFolder},${testsFolder},${ESLINT_DIRS.join(',')}${checkFolders}}`,
+        );
       }
     }
 

--- a/packages/lumos/src/types/index.ts
+++ b/packages/lumos/src/types/index.ts
@@ -193,7 +193,7 @@ export interface LumosSettings {
    */
   assumptions?: Assumptions;
   /**
-   * Names of extra folder to be checked by tsc (excluded from build) and eslint
+   * Names of extra folders to be checked by tsc (excluded from build) and eslint
    */
   checkedFolders?: string[];
 }

--- a/packages/lumos/src/types/index.ts
+++ b/packages/lumos/src/types/index.ts
@@ -192,4 +192,8 @@ export interface LumosSettings {
    * @see https://babeljs.io/docs/en/assumptions
    */
   assumptions?: Assumptions;
+  /**
+   * Names of extra folder to be checked by tsc (excluded from build) and eslint
+   */
+  checkedFolders?: string[];
 }


### PR DESCRIPTION
This option allows for specifying extra folders (besides default `src`, `tests` and `types`) which should be checked and lint by `tsc` and `eslint`, however, still excluded from the build.

The option will result in adding the specified folders to `include` blobs in `tsconfig.eslint.json`. It is useful for having various examples or resources folders checked in development.