### PR TITLE
fix: Update GraphQL transformer after upgrade to Jest 28.

### DIFF
--- a/packages/config-jest/transformers/graphql.js
+++ b/packages/config-jest/transformers/graphql.js
@@ -1,6 +1,8 @@
 const loader = require('graphql-tag/loader');
 
 exports.process = function process(src) {
-  // eslint-disable-next-line no-empty-function -- needed
-  return loader.call({ cacheable() {} }, src);
+  return {
+    // eslint-disable-next-line no-empty-function -- needed
+    code: loader.call({ cacheable() {} }, src),
+  };
 };


### PR DESCRIPTION
We have to update GraphQL transformer to be compatible with Jest 28 ([See docs here](https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer))